### PR TITLE
feat: ターミナル環境の強化 (tmux + プロンプトエンジン切り替え)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,187 @@
-
 # Develify
+
+dotfiles 管理 & ワンライナーセットアップシステム。
+macOS / Ubuntu / WSL に対応し、一つのコマンドで開発環境を構築します。
 
 ## Features
 
-1. anyenvのインストール
-2. starshipでテンションの上がるコンソール画面
-3. exaで ls を拡張
-4. mac(zsh) / ubuntu / wsl に対応
-5. wslは特別なコマンドを追加（wstorm / pstorm / rmine / stree）し、開発に便利なWindowsアプリを起動
+- **ワンライナーセットアップ** — プラットフォーム別の `init.sh` 1つで全環境を構築
+- **プロンプトエンジン切り替え** — starship ⇔ oh-my-posh をコマンド一つで切り替え ([詳細](docs/prompt-switch.md))
+- **tmux 環境** — TPM + tmux-powerline によるモダンな tmux 環境 ([詳細](docs/tmux.md))
+- **anyenv** — 言語バージョン管理 (nodenv, rbenv, pyenv 等)
+- **exa** — `ls` の拡張版 (アイコン・ツリー表示)
+- **Solarized dircolors** — ターミナルカラーの統一
+- **Nerd Font** — JetBrainsMono Nerd Font によるアイコン対応
+- **WSL 拡張コマンド** — wstorm / pstorm / rmine / stree (Windows アプリ連携)
 
-WIP::
+## Quick Start
 
-参考にしている記事
+```bash
+# リポジトリをクローン
+git clone https://github.com/wireframeslayout/develify.git ~/develify
 
-anyenv
-https://qiita.com/282Haniwa/items/71a48a10952413416d18
+# プラットフォームに合った init.sh を実行
+bash ~/develify/startup/ubuntu/init.sh   # Ubuntu
+bash ~/develify/startup/wsl/init.sh      # WSL
+bash ~/develify/startup/mac/init.sh      # macOS
+```
 
+これだけで以下が自動的にセットアップされます：
 
-macのコマンドラインでのフォントインストール方法について
-https://apple.stackexchange.com/questions/240381/installing-fonts-from-terminal-instead-of-font-book
+1. シンボリックリンクの作成 (`.bashrc`, `.tmux.conf` 等)
+2. Starship プロンプトのインストール
+3. oh-my-posh のインストール
+4. anyenv のインストール
+5. exa のインストール
+6. TPM (Tmux Plugin Manager) のインストール
+7. NeoBundle (Vim プラグインマネージャ) のインストール
 
+### tmux プラグインの初回セットアップ
 
-おしゃれなターミナル
-https://zenn.dev/ryuu/articles/customize-your-terminal
+```bash
+tmux                  # tmux を起動
+# Prefix + I          # TPM がプラグインを一括インストール
+```
 
-Starshipのインストール方法
-https://starship.rs/guide/#%F0%9F%9A%80-installation
+## Project Structure
 
-Starshipのフォント
-https://www.nerdfonts.com/font-downloads
+```
+develify/
+├── README.md
+├── docs/
+│   ├── prompt-switch.md          # プロンプト切り替え詳細ドキュメント
+│   └── tmux.md                   # tmux 設定詳細ドキュメント
+├── dotfiles/
+│   ├── .tmux.conf                # tmux 設定 (TPM + tmux-powerline)
+│   ├── .vimrc                    # Vim 設定 (NeoBundle)
+│   ├── .ideavimrc                # JetBrains IDE Vim キーバインド
+│   ├── .dircolors-solarized/     # Solarized カラー定義
+│   ├── conf/
+│   │   ├── init.bash             # bash 共通設定 (PATH, alias, anyenv)
+│   │   ├── init.zsh              # zsh 共通設定
+│   │   ├── init_prompt.bash      # bash プロンプト初期化 (starship/oh-my-posh 分岐)
+│   │   └── init_prompt.zsh       # zsh プロンプト初期化
+│   ├── scripts/
+│   │   ├── .bashrc_mac           # macOS 用 bashrc
+│   │   ├── .bashrc_ubuntu        # Ubuntu 用 bashrc
+│   │   ├── .bashrc_wsl           # WSL 用 bashrc
+│   │   ├── .zshrc_mac            # macOS 用 zshrc
+│   │   ├── .zshrc_ubuntu         # Ubuntu 用 zshrc
+│   │   ├── .zshrc_wsl            # WSL 用 zshrc
+│   │   └── prompt-switch.sh      # プロンプトエンジン切り替えコマンド
+│   ├── ohmyposh/
+│   │   └── develify.omp.json     # oh-my-posh デフォルトテーマ
+│   └── tmux-powerline/
+│       ├── config.sh             # tmux-powerline 設定
+│       └── themes/
+│           └── develify.sh       # tmux-powerline カスタムテーマ
+├── starship/
+│   └── starship.toml             # Starship デフォルトテーマ
+├── startup/
+│   ├── common/
+│   │   ├── sh/
+│   │   │   ├── init_slink.sh           # シンボリックリンク作成
+│   │   │   ├── install_anyenv.sh       # anyenv インストール
+│   │   │   ├── install_exa.sh          # exa インストール
+│   │   │   ├── install_ohmyposh.sh     # oh-my-posh インストール
+│   │   │   ├── install_starship.sh     # Starship インストール
+│   │   │   ├── install_starship_font_linux.sh  # Nerd Font (Linux)
+│   │   │   ├── install_starship_font_mac.sh    # Nerd Font (macOS)
+│   │   │   └── install_tpm.sh          # TPM インストール
+│   │   ├── vim/
+│   │   │   └── install_neobundle.sh    # NeoBundle インストール
+│   │   └── zsh/
+│   │       └── init_slink.zsh          # zsh 用シンボリックリンク作成
+│   ├── mac/
+│   │   ├── init.sh               # macOS セットアップエントリーポイント
+│   │   ├── init.zsh              # macOS zsh セットアップ
+│   │   └── install_homebrew.sh   # Homebrew インストール
+│   ├── ubuntu/
+│   │   └── init.sh               # Ubuntu セットアップエントリーポイント
+│   └── wsl/
+│       └── init.sh               # WSL セットアップエントリーポイント
+├── commands/
+│   └── stree.cmd                 # Windows 用 SourceTree コマンド
+└── powershell/
+    └── wsl_port.ps1              # WSL ポートフォワーディング
+```
 
-StarshipでフォントをLinuxに入れる場合の処理
-https://gist.github.com/matthewjberger/7dd7e079f282f8138a9dc3b045ebefa0
+## Symlink Map
 
+`init_slink.sh` が作成するシンボリックリンクの一覧：
 
-exaのインストール
-https://the.exa.website/install/linux#manual
+| リンク元 (ホーム) | リンク先 (develify) |
+|---|---|
+| `~/conf.d/` | `dotfiles/conf/` |
+| `~/.bashrc` | `dotfiles/scripts/.bashrc_{platform}` |
+| `~/.dircolors-solarized/` | `dotfiles/.dircolors-solarized/` |
+| `~/.vimrc` | `dotfiles/.vimrc` |
+| `~/.tmux.conf` | `dotfiles/.tmux.conf` |
+| `~/.tmux-powerline/` | `dotfiles/tmux-powerline/` |
+| `~/.ohmyposhconf/` | `dotfiles/ohmyposh/` |
+| `~/.starshipconf/` | `starship/` |
+| `~/bin/prompt-switch` | `dotfiles/scripts/prompt-switch.sh` |
+
+## Shell Initialization Flow
+
+```
+シェル起動
+  │
+  ├─ ~/.bashrc (or ~/.zshrc)          ← platform別 RC ファイル
+  │    │
+  │    ├─ source ~/conf.d/init.bash   ← 共通設定 (PATH, alias, anyenv, exa)
+  │    │
+  │    └─ source ~/conf.d/init_prompt.bash  ← プロンプトエンジン初期化
+  │         │
+  │         ├─ ~/.prompt_engine を読み込み
+  │         │
+  │         ├─ [starship]  → eval "$(starship init bash)"
+  │         └─ [ohmyposh]  → eval "$(oh-my-posh init bash --config ...)"
+  │
+  └─ プロンプト表示
+```
+
+## Prompt Engine
+
+Starship (デフォルト) と oh-my-posh をコマンドで切り替えられます。
+
+```bash
+prompt-switch starship                  # Starship に切り替え
+prompt-switch ohmyposh                  # oh-my-posh に切り替え
+prompt-switch ohmyposh -t night-owl     # oh-my-posh + テーマ指定
+
+source ~/.bashrc                        # 反映
+```
+
+詳細は [docs/prompt-switch.md](docs/prompt-switch.md) を参照。
+
+## tmux
+
+TPM + tmux-powerline でモダンな tmux 環境を構築しています。
+
+```
+┌─ [session] [hostname] [mode] [git branch] ──── [pwd] [load] [date] [time] ─┐
+│                                                                             │
+│  ターミナル                                                                  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+詳細は [docs/tmux.md](docs/tmux.md) を参照。
+
+## Requirements
+
+- Git
+- Bash >= 3.2
+- curl
+- [Nerd Font](https://www.nerdfonts.com/font-downloads) (JetBrainsMono 推奨)
+
+## References
+
+- [Starship](https://starship.rs/)
+- [oh-my-posh](https://ohmyposh.dev/)
+- [tmux-powerline](https://github.com/erikw/tmux-powerline)
+- [TPM](https://github.com/tmux-plugins/tpm)
+- [anyenv](https://github.com/anyenv/anyenv)
+- [exa](https://the.exa.website/)
+- [Nerd Fonts](https://www.nerdfonts.com/)

--- a/README.md
+++ b/README.md
@@ -176,6 +176,68 @@ TPM + tmux-powerline でモダンな tmux 環境を構築しています。
 - curl
 - [Nerd Font](https://www.nerdfonts.com/font-downloads) (JetBrainsMono 推奨)
 
+## Nerd Font のインストール
+
+Starship・oh-my-posh・tmux-powerline のアイコン表示には **Nerd Font** が必要です。
+**JetBrainsMono Nerd Font** を推奨しています。
+
+### ダウンロード
+
+[Nerd Fonts ダウンロードページ](https://www.nerdfonts.com/font-downloads) から **JetBrainsMono** をダウンロードしてください。
+
+または、develify のインストールスクリプトで自動インストールできます：
+
+```bash
+# Linux
+bash startup/common/sh/install_starship_font_linux.sh
+
+# macOS
+bash startup/common/sh/install_starship_font_mac.sh
+```
+
+### ターミナルへの適用
+
+#### Windows Terminal
+
+1. `設定` → 使用中のプロファイル → `外観`
+2. `フォント フェイス` で `JetBrainsMono Nerd Font` を選択
+3. 保存
+
+> 参考: [oh-my-posh - Windows Terminal](https://ohmyposh.dev/docs/installation/fonts)
+
+#### VS Code 統合ターミナル
+
+`settings.json` に以下を追加：
+
+```json
+{
+  "terminal.integrated.fontFamily": "JetBrainsMono Nerd Font"
+}
+```
+
+#### iTerm2 (macOS)
+
+1. `Preferences` → `Profiles` → `Text`
+2. `Font` で `JetBrainsMono Nerd Font` を選択
+
+> 参考: [Starship - Font Installation](https://starship.rs/guide/#step-2-setup-your-shell-to-use-starship)
+
+#### GNOME Terminal (Ubuntu)
+
+1. `設定` → 使用中のプロファイル → `テキスト`
+2. `カスタムフォント` にチェックを入れ、`JetBrainsMono Nerd Font` を選択
+
+#### Alacritty
+
+`alacritty.toml` に以下を追加：
+
+```toml
+[font.normal]
+family = "JetBrainsMono Nerd Font"
+```
+
+> 詳細: [oh-my-posh Fonts ドキュメント](https://ohmyposh.dev/docs/installation/fonts) | [Nerd Fonts 公式](https://www.nerdfonts.com/)
+
 ## References
 
 - [Starship](https://starship.rs/)

--- a/docs/prompt-switch.md
+++ b/docs/prompt-switch.md
@@ -1,0 +1,155 @@
+# Prompt Engine 切り替え
+
+Starship と oh-my-posh をワンコマンドで切り替え可能です。
+デフォルトは Starship が有効になっています。
+
+## コマンド
+
+```bash
+prompt-switch {starship|ohmyposh} [-t|--theme <theme_name>]
+```
+
+| 引数 | 必須 | 説明 |
+|---|---|---|
+| `starship` / `ohmyposh` | Yes | 使用するプロンプトエンジン |
+| `-t`, `--theme` | No | テーマ名。省略時はデフォルトテーマ |
+
+## 使用例
+
+```bash
+# Starship (デフォルトテーマ)
+prompt-switch starship
+
+# Starship + カスタムテーマ
+prompt-switch starship -t tokyo-night
+
+# oh-my-posh (develify テーマ)
+prompt-switch ohmyposh
+
+# oh-my-posh + ビルトインテーマ
+prompt-switch ohmyposh -t night-owl
+
+# 切り替え後にシェルに反映
+source ~/.bashrc    # bash の場合
+source ~/.zshrc     # zsh の場合
+```
+
+## 仕組み
+
+### 状態ファイル
+
+`~/.prompt_engine` に現在のエンジンとテーマが保存されます。
+
+```bash
+PROMPT_ENGINE="starship"
+PROMPT_THEME=""
+```
+
+このファイルはシェル起動時に `init_prompt.bash` (または `.zsh`) から読み込まれ、
+適切なプロンプトエンジンが初期化されます。
+ファイルが存在しない場合は、Starship + デフォルトテーマで動作します (後方互換)。
+
+### 処理フロー
+
+```
+prompt-switch 実行
+  │
+  ├─ エンジンのインストール確認
+  ├─ テーマの存在確認
+  └─ ~/.prompt_engine を更新
+        │
+        ▼
+source ~/.bashrc (ユーザーが実行)
+  │
+  └─ init_prompt.bash
+       │
+       ├─ ~/.prompt_engine を読み込み
+       ├─ PROMPT_ENGINE で分岐
+       │
+       ├─ [starship]
+       │    ├─ STARSHIP_CONFIG を設定
+       │    └─ eval "$(starship init bash)"
+       │
+       └─ [ohmyposh]
+            ├─ テーマパスを解決
+            └─ eval "$(oh-my-posh init bash --config <path>)"
+```
+
+## テーマ
+
+### Starship テーマ
+
+| テーマ指定 | 解決先 |
+|---|---|
+| (空 = デフォルト) | `~/.starshipconf/starship.toml` |
+| `tokyo-night` | `~/.starshipconf/tokyo-night.toml` |
+
+カスタムテーマの追加：
+
+```bash
+# Starship プリセットから生成
+starship preset tokyo-night -o ~/.starshipconf/tokyo-night.toml
+
+# または手動で TOML ファイルを作成
+vi ~/.starshipconf/my-theme.toml
+
+# 切り替え
+prompt-switch starship -t my-theme
+```
+
+`~/.starshipconf/` は `starship/` ディレクトリへのシンボリックリンクです。
+リポジトリに TOML ファイルを追加すれば、全環境で利用できます。
+
+### oh-my-posh テーマ
+
+| テーマ指定 | 解決先 |
+|---|---|
+| (空 = デフォルト) | `~/.ohmyposhconf/develify.omp.json` |
+| `night-owl` | oh-my-posh ビルトインテーマ (テーマ名を直接渡す) |
+| `my-custom` | `~/.ohmyposhconf/my-custom.omp.json` (ローカルファイル優先) |
+
+カスタムテーマの追加：
+
+```bash
+# ビルトインテーマをエクスポートしてカスタマイズ
+oh-my-posh config export --config night-owl --output ~/.ohmyposhconf/my-theme.omp.json
+vi ~/.ohmyposhconf/my-theme.omp.json
+
+# 切り替え
+prompt-switch ohmyposh -t my-theme
+```
+
+ビルトインテーマの一覧は `~/.cache/oh-my-posh/themes/` で確認できます。
+
+`~/.ohmyposhconf/` は `dotfiles/ohmyposh/` ディレクトリへのシンボリックリンクです。
+リポジトリに JSON ファイルを追加すれば、全環境で利用できます。
+
+### develify テーマ (oh-my-posh デフォルト)
+
+`dotfiles/ohmyposh/develify.omp.json` は以下のセグメントで構成されています：
+
+**左プロンプト (1行目):**
+- OS アイコン (WSL 表示対応)
+- ユーザー名@ホスト名
+- カレントパス (短縮表示)
+- Git ステータス (ブランチ、変更、stash)
+
+**右プロンプト:**
+- Node.js バージョン
+- Python バージョン (venv 対応)
+- 時刻
+
+**2行目:**
+- 入力プロンプト (`❯`) — エラー時は赤色
+
+## 関連ファイル
+
+| ファイル | 役割 |
+|---|---|
+| `dotfiles/scripts/prompt-switch.sh` | CLI 切り替えコマンド本体 |
+| `dotfiles/conf/init_prompt.bash` | bash 用プロンプト初期化スクリプト |
+| `dotfiles/conf/init_prompt.zsh` | zsh 用プロンプト初期化スクリプト |
+| `starship/starship.toml` | Starship デフォルトテーマ |
+| `dotfiles/ohmyposh/develify.omp.json` | oh-my-posh デフォルトテーマ |
+| `startup/common/sh/install_starship.sh` | Starship インストーラ |
+| `startup/common/sh/install_ohmyposh.sh` | oh-my-posh インストーラ |

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -1,0 +1,146 @@
+# tmux 設定
+
+TPM (Tmux Plugin Manager) と tmux-powerline によるモダンな tmux 環境です。
+
+## セットアップ
+
+`init.sh` を実行すると TPM が自動インストールされます。
+tmux 起動後に `Prefix + I` でプラグインを一括インストールしてください。
+
+```bash
+tmux              # tmux を起動
+# Prefix + I      # プラグインインストール (初回のみ)
+```
+
+## ステータスバー
+
+tmux-powerline による Powerline スタイルのステータスバーが上部に表示されます。
+
+```
+┌─[session][hostname][mode][git branch]──────[pwd][load][date_day][date][time]─┐
+│                                                                              │
+│  ターミナル                                                                   │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 左ステータスバー
+
+| セグメント | 説明 |
+|---|---|
+| `tmux_session_info` | tmux セッション名 |
+| `hostname` | ホスト名 |
+| `mode_indicator` | モード表示 (normal / prefix / copy) |
+| `vcs_branch` | Git ブランチ名 (リポジトリ外では非表示) |
+
+### 右ステータスバー
+
+| セグメント | 説明 |
+|---|---|
+| `pwd` | カレントディレクトリ |
+| `load` | CPU 負荷 |
+| `date_day` | 曜日 |
+| `date` | 日付 |
+| `time` | 時刻 |
+
+### ステータスバーのミュート
+
+```
+Prefix + a    左ステータスのミュート/アンミュート
+Prefix + b    右ステータスのミュート/アンミュート
+```
+
+## キーバインド
+
+### 基本操作
+
+| キー | 動作 |
+|---|---|
+| `Prefix + r` | 設定ファイルのリロード |
+
+### ペイン操作
+
+| キー | 動作 |
+|---|---|
+| `Prefix + \|` | 縦分割 (カレントパス引き継ぎ) |
+| `Prefix + -` | 横分割 (カレントパス引き継ぎ) |
+| `Prefix + h` | 左ペインに移動 |
+| `Prefix + j` | 下ペインに移動 |
+| `Prefix + k` | 上ペインに移動 |
+| `Prefix + l` | 右ペインに移動 |
+| `Prefix + H` | ペインを左にリサイズ (連打可) |
+| `Prefix + J` | ペインを下にリサイズ (連打可) |
+| `Prefix + K` | ペインを上にリサイズ (連打可) |
+| `Prefix + L` | ペインを右にリサイズ (連打可) |
+| `Ctrl + o` | ペインをローテーション (Prefix 不要) |
+
+### ウィンドウ操作
+
+| キー | 動作 |
+|---|---|
+| `Prefix + Ctrl-h` | 前のウィンドウに移動 (連打可) |
+| `Prefix + Ctrl-l` | 次のウィンドウに移動 (連打可) |
+
+### セッション管理 (tmux-resurrect)
+
+| キー | 動作 |
+|---|---|
+| `Prefix + Ctrl-s` | セッションを保存 |
+| `Prefix + Ctrl-r` | セッションを復元 |
+
+tmux-continuum によりセッションは自動保存され、tmux 起動時に自動復元されます。
+
+### クリップボード (tmux-yank)
+
+tmux-yank により、コピーモードで選択したテキストがシステムクリップボードに自動コピーされます。
+
+## プラグイン一覧
+
+| プラグイン | 用途 |
+|---|---|
+| [tpm](https://github.com/tmux-plugins/tpm) | プラグインマネージャ |
+| [tmux-sensible](https://github.com/tmux-plugins/tmux-sensible) | 万人向けデフォルト設定 |
+| [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) | セッション保存・復元 |
+| [tmux-continuum](https://github.com/tmux-plugins/tmux-continuum) | セッション自動保存・復元 |
+| [tmux-yank](https://github.com/tmux-plugins/tmux-yank) | クリップボード連携 |
+| [tmux-powerline](https://github.com/erikw/tmux-powerline) | Powerline ステータスバー |
+
+## プラグインの更新
+
+```
+Prefix + U    プラグインを一括アップデート
+```
+
+## 基本設定
+
+| 設定 | 値 |
+|---|---|
+| ターミナル | `tmux-256color` + True Color |
+| マウス操作 | 有効 |
+| ウィンドウ番号開始 | 1 |
+| ペイン番号開始 | 1 |
+| ウィンドウ自動リナンバー | 有効 |
+| ステータスバー位置 | 上部 |
+| ESC キー遅延 | なし |
+| スクロールバック | 50,000 行 |
+
+## カスタマイズ
+
+### テーマの変更
+
+`dotfiles/tmux-powerline/themes/develify.sh` を編集してセグメントの追加・削除・色変更ができます。
+
+利用可能なセグメントの一覧は [tmux-powerline segments](https://github.com/erikw/tmux-powerline/tree/main/segments) を参照してください。
+
+### 設定の変更
+
+`dotfiles/tmux-powerline/config.sh` で tmux-powerline の全般設定を変更できます。
+
+## 関連ファイル
+
+| ファイル | 役割 |
+|---|---|
+| `dotfiles/.tmux.conf` | tmux メイン設定ファイル |
+| `dotfiles/tmux-powerline/config.sh` | tmux-powerline 設定 |
+| `dotfiles/tmux-powerline/themes/develify.sh` | カスタムテーマ定義 |
+| `startup/common/sh/install_tpm.sh` | TPM インストールスクリプト |

--- a/dotfiles/.tmux.conf
+++ b/dotfiles/.tmux.conf
@@ -1,40 +1,27 @@
-set -g terminal-overrides 'xterm:colors=256'
-set-option -g default-terminal screen-256color
-set-option -g status-right '#(get_ssid) #(battery -c tmux) [%Y-%m-%d(%a) %H:%M]'
+# ==============================================================================
+# 基本設定
+# ==============================================================================
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ",xterm-256color:Tc"
+set -g mouse on
+set -g base-index 1
+set-window-option -g pane-base-index 1
+set -g renumber-windows on
+set -g status-position top
+set -g escape-time 0
+set -g history-limit 50000
+set -g status-interval 1
+set -g status-justify centre
 
+# ==============================================================================
+# キーバインド
+# ==============================================================================
 # 設定ファイルをリロードする
 bind r source-file ~/.tmux.conf \; display "Reloaded!"
-# ステータスバーをトップに配置する
-set-option -g status-position top
 
-# 左右のステータスバーの長さを決定する
-set-option -g status-left-length 90
-set-option -g status-right-length 90
-
-# #H => マシン名
-# #P => ペイン番号
-# 最左に表示
-set-option -g status-left '#H:[#P]'
-
-# Wi-Fi、バッテリー残量、現在時刻
-# 最右に表示
-set-option -g status-right '#(get_ssid) #(battery -c tmux) [%Y-%m-%d(%a) %H:%M]'
-
-# ステータスバーを Utf-8 に対応
-#set-option -g status-utf8 on
-
-# ステータスバーを1秒毎に描画し直す
-set-option -g status-interval 1
-
-# センタライズ（主にウィンドウ番号など）
-set-option -g status-justify centre
-# ウィンドウとペインの番号を1から開始する（デフォルト0）
-set-option -g base-index 1
-set-window-option -g pane-base-index 1
-
-# Prefix+- で横に、Prefix+| で縦に分割（ペイン）する
-bind-key | split-window -h
-bind-key - split-window -v
+# Prefix+- で横に、Prefix+| で縦に分割（カレントパス引き継ぎ）
+bind-key | split-window -h -c "#{pane_current_path}"
+bind-key - split-window -v -c "#{pane_current_path}"
 
 # Prefix + Ctrl-h/l でウィンドウ切り替え
 # Prefix + Ctrl-h,h,h,h,...と連打できる
@@ -55,8 +42,29 @@ bind-key -r K resize-pane -U 5
 bind-key -r L resize-pane -R 5
 
 # Ctrl-o でペインをローテーションしながら移動
-# Prefix を用いないのでタイプが楽だが、Ctrl-o を使用してしまう
-# 他のソフトウェアの設定に支障をきたさないように注意
 bind-key -n C-o select-pane -t :.+
-#set -g default-command "reattach-to-user-namespace -l /bin/bash"
+
+# ==============================================================================
+# tmux-powerline
+# ==============================================================================
+set -g @tmux_powerline_theme "develify"
+set -g @tmux_powerline_user_config "$HOME/.tmux-powerline/config.sh"
+
+# ==============================================================================
+# tmux-continuum (自動保存・復元)
+# ==============================================================================
+set -g @continuum-restore 'on'
+
+# ==============================================================================
+# プラグイン (TPM管理)
+# ==============================================================================
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @plugin 'tmux-plugins/tmux-yank'
+set -g @plugin 'erikw/tmux-powerline'
+
+# TPM初期化 (最下行に配置必須)
+run '~/.tmux/plugins/tpm/tpm'
 

--- a/dotfiles/conf/init.bash
+++ b/dotfiles/conf/init.bash
@@ -127,6 +127,9 @@ then
     fi
 fi
 
+## ~/bin (oh-my-posh, prompt-switch etc.)
+export PATH="$HOME/bin:$PATH"
+
 #eval `dircolors ~/.dircolors-solarized/dircolors.ansi-light`
 eval `dircolors ~/.dircolors-solarized/dircolors.256dark`
 

--- a/dotfiles/conf/init.bash
+++ b/dotfiles/conf/init.bash
@@ -144,6 +144,3 @@ else
   alias ltl='lt | less -r'
 fi
 
-
-export STARSHIP_CONFIG=~/.starshipconf/starship.toml
-

--- a/dotfiles/conf/init.zsh
+++ b/dotfiles/conf/init.zsh
@@ -24,5 +24,3 @@ else
   alias lt='tree -I "node_modules|.git|.cache|vendor|tmp"'
   alias ltl='lt | less -r'
 fi
-
-export STARSHIP_CONFIG=~/.starshipconf/starship.toml

--- a/dotfiles/conf/init.zsh
+++ b/dotfiles/conf/init.zsh
@@ -9,6 +9,9 @@ then
     fi
 fi
 
+## ~/bin (oh-my-posh, prompt-switch etc.)
+export PATH="$HOME/bin:$PATH"
+
 eval `dircolors ~/.dircolors-solarized/dircolors.256dark`
 
 ## exa alias

--- a/dotfiles/conf/init_prompt.bash
+++ b/dotfiles/conf/init_prompt.bash
@@ -1,0 +1,42 @@
+#!/bin/bash
+# init_prompt.bash - Initialize prompt engine (starship or oh-my-posh) for bash
+# Sourced from .bashrc_* files
+
+PROMPT_ENGINE_FILE="$HOME/.prompt_engine"
+
+# Default: starship
+PROMPT_ENGINE="starship"
+PROMPT_THEME=""
+
+# Load state file if exists
+if [[ -f "$PROMPT_ENGINE_FILE" ]]; then
+    source "$PROMPT_ENGINE_FILE"
+fi
+
+case "$PROMPT_ENGINE" in
+    starship)
+        if command -v starship &>/dev/null; then
+            if [[ -n "$PROMPT_THEME" ]]; then
+                export STARSHIP_CONFIG="$HOME/.starshipconf/${PROMPT_THEME}.toml"
+            else
+                export STARSHIP_CONFIG="$HOME/.starshipconf/starship.toml"
+            fi
+            eval "$(starship init bash)"
+        fi
+        ;;
+    ohmyposh)
+        if command -v oh-my-posh &>/dev/null; then
+            if [[ -n "$PROMPT_THEME" ]]; then
+                # Local theme file takes priority, otherwise use built-in theme name
+                LOCAL_THEME="$HOME/.ohmyposhconf/${PROMPT_THEME}.omp.json"
+                if [[ -f "$LOCAL_THEME" ]]; then
+                    eval "$(oh-my-posh init bash --config "$LOCAL_THEME")"
+                else
+                    eval "$(oh-my-posh init bash --config "$PROMPT_THEME")"
+                fi
+            else
+                eval "$(oh-my-posh init bash --config "$HOME/.ohmyposhconf/develify.omp.json")"
+            fi
+        fi
+        ;;
+esac

--- a/dotfiles/conf/init_prompt.zsh
+++ b/dotfiles/conf/init_prompt.zsh
@@ -1,0 +1,42 @@
+#!/bin/zsh
+# init_prompt.zsh - Initialize prompt engine (starship or oh-my-posh) for zsh
+# Sourced from .zshrc_* files
+
+PROMPT_ENGINE_FILE="$HOME/.prompt_engine"
+
+# Default: starship
+PROMPT_ENGINE="starship"
+PROMPT_THEME=""
+
+# Load state file if exists
+if [[ -f "$PROMPT_ENGINE_FILE" ]]; then
+    source "$PROMPT_ENGINE_FILE"
+fi
+
+case "$PROMPT_ENGINE" in
+    starship)
+        if command -v starship &>/dev/null; then
+            if [[ -n "$PROMPT_THEME" ]]; then
+                export STARSHIP_CONFIG="$HOME/.starshipconf/${PROMPT_THEME}.toml"
+            else
+                export STARSHIP_CONFIG="$HOME/.starshipconf/starship.toml"
+            fi
+            eval "$(starship init zsh)"
+        fi
+        ;;
+    ohmyposh)
+        if command -v oh-my-posh &>/dev/null; then
+            if [[ -n "$PROMPT_THEME" ]]; then
+                # Local theme file takes priority, otherwise use built-in theme name
+                LOCAL_THEME="$HOME/.ohmyposhconf/${PROMPT_THEME}.omp.json"
+                if [[ -f "$LOCAL_THEME" ]]; then
+                    eval "$(oh-my-posh init zsh --config "$LOCAL_THEME")"
+                else
+                    eval "$(oh-my-posh init zsh --config "$PROMPT_THEME")"
+                fi
+            else
+                eval "$(oh-my-posh init zsh --config "$HOME/.ohmyposhconf/develify.omp.json")"
+            fi
+        fi
+        ;;
+esac

--- a/dotfiles/ohmyposh/develify.omp.json
+++ b/dotfiles/ohmyposh/develify.omp.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "version": 2,
+  "final_space": true,
+  "console_title_template": "{{ .Shell }} in {{ .Folder }}",
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "segments": [
+        {
+          "type": "os",
+          "style": "diamond",
+          "foreground": "#ffffff",
+          "background": "#33658A",
+          "leading_diamond": "\ue0b6",
+          "template": " {{ if .WSL }}WSL{{ end }} {{ .Icon }} "
+        },
+        {
+          "type": "session",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b0",
+          "foreground": "#ffffff",
+          "background": "#6A9FB5",
+          "template": " {{ .UserName }}@{{ .HostName }} "
+        },
+        {
+          "type": "path",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b0",
+          "foreground": "#ffffff",
+          "background": "#2E86AB",
+          "properties": {
+            "style": "agnoster_short",
+            "max_depth": 3
+          },
+          "template": " \uf07b {{ .Path }} "
+        },
+        {
+          "type": "git",
+          "style": "powerline",
+          "powerline_symbol": "\ue0b0",
+          "foreground": "#193549",
+          "background": "#95ffa4",
+          "background_templates": [
+            "{{ if or (.Working.Changed) (.Staging.Changed) }}#FF9248{{ end }}",
+            "{{ if and (gt .Ahead 0) (gt .Behind 0) }}#ff4500{{ end }}",
+            "{{ if gt .Ahead 0 }}#B388FF{{ end }}",
+            "{{ if gt .Behind 0 }}#B388FF{{ end }}"
+          ],
+          "properties": {
+            "branch_icon": "\ue725 ",
+            "fetch_status": true,
+            "fetch_stash_count": true
+          },
+          "template": " {{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} "
+        }
+      ]
+    },
+    {
+      "type": "prompt",
+      "alignment": "right",
+      "segments": [
+        {
+          "type": "node",
+          "style": "plain",
+          "foreground": "#6CA35E",
+          "properties": {
+            "fetch_version": true
+          },
+          "template": "\ue718 {{ .Full }} "
+        },
+        {
+          "type": "python",
+          "style": "plain",
+          "foreground": "#FFE873",
+          "properties": {
+            "fetch_version": true,
+            "fetch_virtual_env": true
+          },
+          "template": "\ue235 {{ if .Venv }}({{ .Venv }}) {{ end }}{{ .Full }} "
+        },
+        {
+          "type": "time",
+          "style": "plain",
+          "foreground": "#999999",
+          "template": "\uf017 {{ .CurrentDate | date \"15:04:05\" }} "
+        }
+      ]
+    },
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
+          "type": "text",
+          "style": "plain",
+          "foreground_templates": [
+            "{{ if gt .Code 0 }}#ef5350{{ end }}"
+          ],
+          "foreground": "#ffffff",
+          "template": "\u276f "
+        }
+      ]
+    }
+  ]
+}

--- a/dotfiles/scripts/.bashrc_mac
+++ b/dotfiles/scripts/.bashrc_mac
@@ -34,4 +34,4 @@ else
   alias ltl='lt | less -r'
 fi
 
-eval "$(starship init bash)"
+source ~/conf.d/init_prompt.bash

--- a/dotfiles/scripts/.bashrc_ubuntu
+++ b/dotfiles/scripts/.bashrc_ubuntu
@@ -1,3 +1,3 @@
 . ~/conf.d/init.bash
-eval "$(starship init bash)"
+source ~/conf.d/init_prompt.bash
 #source ~/.bash_prompt

--- a/dotfiles/scripts/.bashrc_wsl
+++ b/dotfiles/scripts/.bashrc_wsl
@@ -20,8 +20,7 @@ function stree () {
 	cmd.exe /c stree $(wslpath -w $1)
 }
 
-eval "$(starship init bash)"
-#source ~/.bash_prompt
+source ~/conf.d/init_prompt.bash
 
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm

--- a/dotfiles/scripts/.zshrc_mac
+++ b/dotfiles/scripts/.zshrc_mac
@@ -36,4 +36,4 @@ typeset -U path PATH
 
 . ~/conf.d/init.zsh
 
-eval "$(starship init zsh)"
+source ~/conf.d/init_prompt.zsh

--- a/dotfiles/scripts/.zshrc_ubuntu
+++ b/dotfiles/scripts/.zshrc_ubuntu
@@ -1,2 +1,2 @@
 . ~/conf.d/init.zsh
-eval "$(starship init zsh)"
+source ~/conf.d/init_prompt.zsh

--- a/dotfiles/scripts/.zshrc_wsl
+++ b/dotfiles/scripts/.zshrc_wsl
@@ -20,4 +20,4 @@ function stree () {
 	cmd.exe /c stree $(wslpath -w $1)
 }
 
-eval "$(starship init zsh)"
+source ~/conf.d/init_prompt.zsh

--- a/dotfiles/scripts/prompt-switch.sh
+++ b/dotfiles/scripts/prompt-switch.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# prompt-switch.sh - Switch between starship and oh-my-posh prompt engines
+#
+# Usage:
+#   prompt-switch {starship|ohmyposh} [-t|--theme <theme_name>]
+#
+# Examples:
+#   prompt-switch starship                    # starship + default (starship.toml)
+#   prompt-switch starship -t tokyo-night     # starship + tokyo-night preset
+#   prompt-switch ohmyposh                    # oh-my-posh + default (develify.omp.json)
+#   prompt-switch ohmyposh -t night-owl       # oh-my-posh + built-in theme
+
+set -euo pipefail
+
+PROMPT_ENGINE_FILE="$HOME/.prompt_engine"
+
+usage() {
+    echo "Usage: prompt-switch {starship|ohmyposh} [-t|--theme <theme_name>]"
+    echo ""
+    echo "Arguments:"
+    echo "  starship    Use starship as prompt engine"
+    echo "  ohmyposh    Use oh-my-posh as prompt engine"
+    echo ""
+    echo "Options:"
+    echo "  -t, --theme <name>  Theme name (default: built-in theme)"
+    echo ""
+    echo "Examples:"
+    echo "  prompt-switch starship"
+    echo "  prompt-switch starship -t tokyo-night"
+    echo "  prompt-switch ohmyposh"
+    echo "  prompt-switch ohmyposh -t night-owl"
+    exit 1
+}
+
+# Parse arguments
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+ENGINE="$1"
+shift
+
+THEME=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -t|--theme)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --theme requires a value."
+                exit 1
+            fi
+            THEME="$2"
+            shift 2
+            ;;
+        *)
+            echo "Error: Unknown option '$1'"
+            usage
+            ;;
+    esac
+done
+
+# Validate engine
+case "$ENGINE" in
+    starship)
+        if ! command -v starship &>/dev/null; then
+            echo "Error: starship is not installed."
+            echo "Install it with: curl -sS https://starship.rs/install.sh | sh"
+            exit 1
+        fi
+
+        # Validate theme if specified
+        if [[ -n "$THEME" ]]; then
+            THEME_FILE="$HOME/.starshipconf/${THEME}.toml"
+            if [[ ! -f "$THEME_FILE" ]]; then
+                echo "Warning: Theme file '$THEME_FILE' not found."
+                echo "You can create it with: starship preset $THEME -o $THEME_FILE"
+                echo "Proceeding anyway (file may be created later)."
+            fi
+        fi
+        ;;
+    ohmyposh)
+        if ! command -v oh-my-posh &>/dev/null; then
+            echo "Error: oh-my-posh is not installed."
+            echo "Install it with: curl -s https://ohmyposh.dev/install.sh | bash -s"
+            exit 1
+        fi
+
+        # Validate theme if specified
+        if [[ -n "$THEME" ]]; then
+            LOCAL_THEME="$HOME/.ohmyposhconf/${THEME}.omp.json"
+            if [[ -f "$LOCAL_THEME" ]]; then
+                echo "Using local theme: $LOCAL_THEME"
+            else
+                echo "Using oh-my-posh built-in theme: $THEME"
+            fi
+        fi
+        ;;
+    *)
+        echo "Error: Unknown engine '$ENGINE'. Use 'starship' or 'ohmyposh'."
+        usage
+        ;;
+esac
+
+# Write state file
+cat > "$PROMPT_ENGINE_FILE" <<EOF
+PROMPT_ENGINE="$ENGINE"
+PROMPT_THEME="$THEME"
+EOF
+
+echo "Prompt engine switched to: $ENGINE"
+if [[ -n "$THEME" ]]; then
+    echo "Theme: $THEME"
+else
+    echo "Theme: default"
+fi
+echo ""
+echo "Run 'source ~/.bashrc' or 'source ~/.zshrc' to apply."

--- a/dotfiles/tmux-powerline/config.sh
+++ b/dotfiles/tmux-powerline/config.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# tmux-powerline configuration
+# See: https://github.com/erikw/tmux-powerline
+
+# Nerd Font (JetBrainsMono) を使用
+export TMUX_POWERLINE_PATCHED_FONT_IN_USE="true"
+
+# テーマ
+export TMUX_POWERLINE_THEME="develify"
+
+# カスタムテーマ・セグメントのパス
+export TMUX_POWERLINE_DIR_USER_THEMES="$HOME/.tmux-powerline/themes"
+export TMUX_POWERLINE_DIR_USER_SEGMENTS="$HOME/.tmux-powerline/segments"
+
+# ステータスバーの更新間隔 (秒)
+export TMUX_POWERLINE_STATUS_INTERVAL=1
+
+# ステータスバーの表示
+export TMUX_POWERLINE_STATUS_VISIBILITY="on"
+
+# ステータスバーの配置
+export TMUX_POWERLINE_STATUS_JUSTIFICATION="centre"
+
+# ステータスバーの長さ
+export TMUX_POWERLINE_STATUS_LEFT_LENGTH="60"
+export TMUX_POWERLINE_STATUS_RIGHT_LENGTH="90"
+
+# Prefix + a でleft、Prefix + b でrightのpowerlineをミュート/アンミュート
+export TMUX_POWERLINE_MUTE_LEFT_KEYBINDING="a"
+export TMUX_POWERLINE_MUTE_RIGHT_KEYBINDING="b"
+
+# デバッグモード (問題発生時に true にする)
+export TMUX_POWERLINE_DEBUG_MODE_ENABLED="false"

--- a/dotfiles/tmux-powerline/themes/develify.sh
+++ b/dotfiles/tmux-powerline/themes/develify.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# shellcheck shell=bash
+# Develify Custom Theme for tmux-powerline
+#
+# Left:  [session] [hostname] [mode_indicator] [git branch]
+# Right: [pwd] [load] [date] [time]
+
+if tp_patched_font_in_use; then
+	TMUX_POWERLINE_SEPARATOR_LEFT_BOLD=""
+	TMUX_POWERLINE_SEPARATOR_LEFT_THIN=""
+	TMUX_POWERLINE_SEPARATOR_RIGHT_BOLD=""
+	TMUX_POWERLINE_SEPARATOR_RIGHT_THIN=""
+else
+	TMUX_POWERLINE_SEPARATOR_LEFT_BOLD="◀"
+	TMUX_POWERLINE_SEPARATOR_LEFT_THIN="❮"
+	TMUX_POWERLINE_SEPARATOR_RIGHT_BOLD="▶"
+	TMUX_POWERLINE_SEPARATOR_RIGHT_THIN="❯"
+fi
+
+# カラー設定
+# 背景: ダークグレー (235), 前景: ホワイト (255)
+TMUX_POWERLINE_DEFAULT_BACKGROUND_COLOR=${TMUX_POWERLINE_DEFAULT_BACKGROUND_COLOR:-'235'}
+TMUX_POWERLINE_DEFAULT_FOREGROUND_COLOR=${TMUX_POWERLINE_DEFAULT_FOREGROUND_COLOR:-'255'}
+
+# shellcheck disable=SC2034
+TMUX_POWERLINE_SEG_AIR_COLOR=$(tp_air_color)
+
+TMUX_POWERLINE_DEFAULT_LEFTSIDE_SEPARATOR=${TMUX_POWERLINE_DEFAULT_LEFTSIDE_SEPARATOR:-$TMUX_POWERLINE_SEPARATOR_RIGHT_BOLD}
+TMUX_POWERLINE_DEFAULT_RIGHTSIDE_SEPARATOR=${TMUX_POWERLINE_DEFAULT_RIGHTSIDE_SEPARATOR:-$TMUX_POWERLINE_SEPARATOR_LEFT_BOLD}
+
+# ウィンドウステータス (アクティブウィンドウ)
+# shellcheck disable=SC2128
+if [ -z "$TMUX_POWERLINE_WINDOW_STATUS_CURRENT" ]; then
+	TMUX_POWERLINE_WINDOW_STATUS_CURRENT=(
+		"#[$(tp_format inverse)]"
+		"$TMUX_POWERLINE_DEFAULT_LEFTSIDE_SEPARATOR"
+		" #I#F "
+		"$TMUX_POWERLINE_SEPARATOR_RIGHT_THIN"
+		" #W "
+		"#[$(tp_format regular)]"
+		"$TMUX_POWERLINE_DEFAULT_LEFTSIDE_SEPARATOR"
+	)
+fi
+
+# ウィンドウステータス (スタイル)
+# shellcheck disable=SC2128
+if [ -z "$TMUX_POWERLINE_WINDOW_STATUS_STYLE" ]; then
+	TMUX_POWERLINE_WINDOW_STATUS_STYLE=(
+		"$(tp_format regular)"
+	)
+fi
+
+# ウィンドウステータス (非アクティブウィンドウ)
+# shellcheck disable=SC2128
+if [ -z "$TMUX_POWERLINE_WINDOW_STATUS_FORMAT" ]; then
+	TMUX_POWERLINE_WINDOW_STATUS_FORMAT=(
+		"#[$(tp_format regular)]"
+		"  #I#{?window_flags,#F, } "
+		"$TMUX_POWERLINE_SEPARATOR_RIGHT_THIN"
+		" #W "
+	)
+fi
+
+# ==============================================================================
+# 左ステータスバー: セッション → ホスト名 → モードインジケータ → Gitブランチ
+# ==============================================================================
+# shellcheck disable=SC1143,SC2128
+if [ -z "$TMUX_POWERLINE_LEFT_STATUS_SEGMENTS" ]; then
+	TMUX_POWERLINE_LEFT_STATUS_SEGMENTS=(
+		"tmux_session_info 148 234"
+		"hostname 33 0"
+		"mode_indicator 165 0"
+		"vcs_branch 29 88"
+	)
+fi
+
+# ==============================================================================
+# 右ステータスバー: CWD → CPU負荷 → 日付 → 時刻
+# ==============================================================================
+# shellcheck disable=SC1143,SC2128
+if [ -z "$TMUX_POWERLINE_RIGHT_STATUS_SEGMENTS" ]; then
+	TMUX_POWERLINE_RIGHT_STATUS_SEGMENTS=(
+		"pwd 89 211"
+		"load 237 167"
+		"date_day 235 136"
+		"date 235 136 ${TMUX_POWERLINE_SEPARATOR_LEFT_THIN}"
+		"time 235 136 ${TMUX_POWERLINE_SEPARATOR_LEFT_THIN}"
+	)
+fi

--- a/startup/common/sh/init_slink.sh
+++ b/startup/common/sh/init_slink.sh
@@ -23,3 +23,6 @@ ln -nsf $SCRIPT_DIR/../../../dotfiles/.dircolors-solarized/ ~/.dircolors-solariz
 ln -sf $SCRIPT_DIR/../../../dotfiles/.vimrc ~/.vimrc
 ln -sf $SCRIPT_DIR/../../../dotfiles/.tmux.conf ~/.tmux.conf
 ln -nsf $SCRIPT_DIR/../../../dotfiles/tmux-powerline/ ~/.tmux-powerline
+ln -nsf $SCRIPT_DIR/../../../dotfiles/ohmyposh/ ~/.ohmyposhconf
+mkdir -p ~/bin
+ln -sf $SCRIPT_DIR/../../../dotfiles/scripts/prompt-switch.sh ~/bin/prompt-switch

--- a/startup/common/sh/init_slink.sh
+++ b/startup/common/sh/init_slink.sh
@@ -22,3 +22,4 @@ ln -sf $SCRIPT_DIR/../../../dotfiles/scripts/$SCRIPTNAME ~/.bashrc
 ln -nsf $SCRIPT_DIR/../../../dotfiles/.dircolors-solarized/ ~/.dircolors-solarized
 ln -sf $SCRIPT_DIR/../../../dotfiles/.vimrc ~/.vimrc
 ln -sf $SCRIPT_DIR/../../../dotfiles/.tmux.conf ~/.tmux.conf
+ln -nsf $SCRIPT_DIR/../../../dotfiles/tmux-powerline/ ~/.tmux-powerline

--- a/startup/common/sh/install_ohmyposh.sh
+++ b/startup/common/sh/install_ohmyposh.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## install oh-my-posh
+## https://ohmyposh.dev/docs/installation/linux
+
+if command -v oh-my-posh &>/dev/null; then
+    echo "oh-my-posh is already installed."
+else
+    echo "Installing oh-my-posh..."
+    curl -s https://ohmyposh.dev/install.sh | bash -s
+    echo "oh-my-posh installed successfully."
+fi

--- a/startup/common/sh/install_tpm.sh
+++ b/startup/common/sh/install_tpm.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+## install tpm (Tmux Plugin Manager)
+## https://github.com/tmux-plugins/tpm
+
+TPM_DIR="$HOME/.tmux/plugins/tpm"
+
+if [ -d "$TPM_DIR" ]; then
+    echo "tpm is already installed."
+else
+    echo "Installing tpm..."
+    git clone https://github.com/tmux-plugins/tpm "$TPM_DIR"
+    echo "tpm installed successfully."
+    echo "Start tmux and press 'prefix + I' to install plugins."
+fi

--- a/startup/mac/init.sh
+++ b/startup/mac/init.sh
@@ -12,6 +12,9 @@ bash $SCRIPT_DIR/../common/sh/init_slink.sh mac
 ## install starship
 bash $SCRIPT_DIR/../common/sh/install_starship.sh
 
+## install oh-my-posh
+bash $SCRIPT_DIR/../common/sh/install_ohmyposh.sh
+
 ## install anyenv
 bash $SCRIPT_DIR/../common/sh/install_anyenv.sh
 

--- a/startup/mac/init.sh
+++ b/startup/mac/init.sh
@@ -18,6 +18,9 @@ bash $SCRIPT_DIR/../common/sh/install_anyenv.sh
 ## install exa
 bash $SCRIPT_DIR/../common/sh/install_exa.sh mac
 
+## install tpm (tmux plugin manager)
+bash $SCRIPT_DIR/../common/sh/install_tpm.sh
+
 ## install neobundle
 bash $SCRIPT_DIR/../common/vim/install_neobundle.sh
 

--- a/startup/ubuntu/init.sh
+++ b/startup/ubuntu/init.sh
@@ -11,6 +11,8 @@ bash $SCRIPT_DIR/../common/sh/init_slink.sh ubuntu
 ## install starship
 bash $SCRIPT_DIR/../common/sh/install_starship.sh
 
+## install oh-my-posh
+bash $SCRIPT_DIR/../common/sh/install_ohmyposh.sh
 
 ## install anyenv
 bash $SCRIPT_DIR/../common/sh/install_anyenv.sh

--- a/startup/ubuntu/init.sh
+++ b/startup/ubuntu/init.sh
@@ -18,6 +18,9 @@ bash $SCRIPT_DIR/../common/sh/install_anyenv.sh
 ## install exa
 bash $SCRIPT_DIR/../common/sh/install_exa.sh
 
+## install tpm (tmux plugin manager)
+bash $SCRIPT_DIR/../common/sh/install_tpm.sh
+
 ## install neobundle
 bash $SCRIPT_DIR/../common/vim/install_neobundle.sh
 

--- a/startup/wsl/init.sh
+++ b/startup/wsl/init.sh
@@ -18,6 +18,9 @@ bash $SCRIPT_DIR/../common/sh/install_anyenv.sh
 ## install exa
 bash $SCRIPT_DIR/../common/sh/install_exa.sh
 
+## install tpm (tmux plugin manager)
+bash $SCRIPT_DIR/../common/sh/install_tpm.sh
+
 ## install neobundle
 bash $SCRIPT_DIR/../common/vim/install_neobundle.sh
 

--- a/startup/wsl/init.sh
+++ b/startup/wsl/init.sh
@@ -11,6 +11,8 @@ bash $SCRIPT_DIR/../common/sh/init_slink.sh wsl
 ## install starship
 bash $SCRIPT_DIR/../common/sh/install_starship.sh
 
+## install oh-my-posh
+bash $SCRIPT_DIR/../common/sh/install_ohmyposh.sh
 
 ## install anyenv
 bash $SCRIPT_DIR/../common/sh/install_anyenv.sh


### PR DESCRIPTION
## 概要

ターミナル環境を全面的に強化するPRです。

## 変更内容

### 1. tmux 環境の刷新 (Closes #2)

- `.tmux.conf` を全面書き換え (True Color, マウス有効化, TPM + プラグイン管理)
- tmux-powerline によるカスタムテーマ `develify` でステータスバーを構築
- tmux-resurrect / tmux-continuum によるセッション自動保存・復元
- tmux-yank によるクリップボード連携

### 2. プロンプトエンジン切り替え機能 (Closes #1)

- `prompt-switch` コマンドで starship ⇔ oh-my-posh をワンコマンドで切り替え
- `~/.prompt_engine` による状態管理
- `init_prompt.bash` / `init_prompt.zsh` でシェル起動時に自動分岐
- oh-my-posh デフォルトテーマ `develify.omp.json` を追加
- 全 RC ファイル (.bashrc_*, .zshrc_*) を `source init_prompt` に統一
- 後方互換: `~/.prompt_engine` がない場合は従来通り starship で動作

### 3. ドキュメント整備

- `README.md` を全面刷新 (Quick Start, Project Structure, Symlink Map, Shell Flow)
- `docs/prompt-switch.md` — プロンプト切り替えの詳細ドキュメント
- `docs/tmux.md` — tmux キーバインド・プラグイン・ステータスバーの詳細ドキュメント

## コミット一覧

- `6fdd166` feat: tmux環境の強化 (TPM + tmux-powerline + プラグイン導入)
- `5113401` feat: starship ⇔ oh-my-posh プロンプトエンジン切り替え機能
- `ac57af0` fix: ~/bin を PATH に追加 (oh-my-posh, prompt-switch 用)
- `fc0799d` docs: README.md を刷新、docs/ を追加

## 新規ファイル

| ファイル | 用途 |
|---|---|
| `dotfiles/tmux-powerline/config.sh` | tmux-powerline 設定 |
| `dotfiles/tmux-powerline/themes/develify.sh` | tmux-powerline カスタムテーマ |
| `dotfiles/conf/init_prompt.bash` | bash プロンプト初期化 |
| `dotfiles/conf/init_prompt.zsh` | zsh プロンプト初期化 |
| `dotfiles/scripts/prompt-switch.sh` | プロンプトエンジン切り替え CLI |
| `dotfiles/ohmyposh/develify.omp.json` | oh-my-posh デフォルトテーマ |
| `startup/common/sh/install_tpm.sh` | TPM インストーラ |
| `startup/common/sh/install_ohmyposh.sh` | oh-my-posh インストーラ |
| `docs/prompt-switch.md` | プロンプト切り替えドキュメント |
| `docs/tmux.md` | tmux 設定ドキュメント |

## テスト

- [x] WSL2 環境で `init.sh` 実行 → セットアップ完了
- [x] tmux 起動 → Prefix + I でプラグインインストール → powerline ステータスバー表示
- [x] `prompt-switch starship` → starship プロンプト表示
- [x] `prompt-switch ohmyposh` → oh-my-posh プロンプト表示
- [x] `source ~/.bashrc` でプロンプト切り替え反映
